### PR TITLE
writeDouble produces little-endian values instead of big-endian

### DIFF
--- a/node-amf/serialize.js
+++ b/node-amf/serialize.js
@@ -282,7 +282,7 @@ AMFSerializer.prototype.writeDouble = function( value, writeMarker ){
 		this.s += '\0\0\0\0\0\0\xF8\x7F';
 	}
 	else {
-		this.s += this.leParser.fromDouble( value );
+		this.s += this.beParser.fromDouble( value );
 	}
 	return this.s;
 }


### PR DESCRIPTION
Hi. I'm not sure if they're invalid or just different, but I can tell that pyamf (which works) uses big endian so I'd assume that this is a bug.
