### PR TITLE
Fix broken reserialization of object reference

### DIFF
--- a/node-amf/http-server.js
+++ b/node-amf/http-server.js
@@ -124,7 +124,7 @@ exports.start = function( listenPort, listenHost, methods, timeout ){
 					//sys.puts( utils.hex(bin) );
 					//sys.puts( sys.inspect(responsePacket) );
 					res.writeHead( 200, {
-						'Content-Type': 'application/amf',
+						'Content-Type': 'application/x-amf',
 						'Content-Length': bin.length 
 					} );
 					res.write( bin, "binary" );

--- a/node-amf/serialize.js
+++ b/node-amf/serialize.js
@@ -187,12 +187,11 @@ AMFSerializer.prototype.writeArray = function( value ){
 	if( this.version === amf.AMF3 ){
 		this.writeU8( amf.AMF3_ARRAY );
 		// support object references
-		if( value.__amfidx != null ){
-			var n = ( value.__amfidx << 1 );
-			return this.writeU29( n );
+		var n = this.refObj.indexOf( value );
+		if( n != -1){
+			return this.writeU29( n << 1);
 		}
 		// else index object reference
-		value.__amfidx = this.refObj.length;
 		this.refObj.push( value );
 		// flag with XXXXXXX1 indicating length of dense portion with instance
 		var flag = ( len << 1 ) | 1;
@@ -221,19 +220,18 @@ AMFSerializer.prototype.writeObject = function( value ){
 	}
 	this.writeU8( amf.AMF3_OBJECT );
 	// support object references
-	if( value.__amfidx != null ){
-		var n = ( value.__amfidx << 1 );
-		return this.writeU29( n );
+	var n = this.refObj.indexOf( value );
+	if( n != -1 ){
+		return this.writeU29( n << 1 );
 	}
 	// else index object reference
-	value.__amfidx = this.refObj.length;
 	this.refObj.push( value );
 	// flag with instance, no traits, no externalizable
 	this.writeU29( 11 );
 	this.writeUTF8('Object');
 	// write serializable properties
 	for( var s in value ){
-		if( typeof value[s] !== 'function' && s !== '__amfidx' ){
+		if( typeof value[s] !== 'function' ){
 			this.writeUTF8(s);
 			this.writeValue( value[s] );
 		}

--- a/test.js
+++ b/test.js
@@ -42,8 +42,10 @@ var tests = [
 	['date object (now)', new Date() ],
 	// plain objects
 	['empty object', {} ],
-	['keyed object', { foo:'bar', 'foo bar':'baz' } ]
+	['keyed object', { foo:'bar', 'foo bar':'baz' } ],
+	['refs object', { foo: _ = { a: 12 }, bar: _ } ]
 ];
+
 
 
 
@@ -58,6 +60,8 @@ for( var t = 0, n = 0; t < tests.length; t++ ){
 		var s = sys.inspect(value).replace(/\n/g,' ');
 		sys.puts( ' > ' +descr+ ': ' + s);
 		// serialize and show AMF packet
+		// serializing twice must not affect results
+		amf.serializer().writeValue( value );
 		var Ser = amf.serializer();
 		var bin = Ser.writeValue( value );
 		//sys.puts( utils.hex(bin,16) );


### PR DESCRIPTION
Serialization alter the Object and Array values by adding an extra property.
When reserializing (with a new serializer) with the same (altered) value;
this "hidden" property breaks the binary output.
