### PR TITLE
Adding workaround for Issue #10

### DIFF
--- a/node-amf/serialize.js
+++ b/node-amf/serialize.js
@@ -260,7 +260,10 @@ AMFSerializer.prototype.writeDate = function( d ){
 AMFSerializer.prototype.writeNumber = function( value, writeMarker ){
 	// serialize as integers if possible
 	var n = parseInt( value );
-	if( n === value && n >= 0 && n < 0x20000000 ){
+	// NOTE: writing large integers as doubles due to https://github.com/timwhitlock/node-amf/issues/10
+	// original largest size was 0x20000000
+	if( n === value && n >= 0 && n < 0x00200000 ){
+
 		return this.writeU29( value, writeMarker );
 	}
 	return this.writeDouble( value, writeMarker );


### PR DESCRIPTION
The largest U29 we write is now 0x00200000.  Anything larger is a Double.  https://github.com/timwhitlock/node-amf/issues/10.  This is not as efficient, but I believe it is more correct or less likely to cause issues when either the client or server is using a different AMF3 library.
