### PR TITLE
Add support for traits/types

### DIFF
--- a/node-amf/deserialize.js
+++ b/node-amf/deserialize.js
@@ -330,13 +330,8 @@ AMFDeserializer.prototype.readObject = function( version ){
 		}
 		// Have traits - Construct instance
 		// @todo support class mapping somehow?
-<<<<<<< HEAD
-		this.refObj.push( Obj );
-		for( var i = 0, sz = Traits.props.length; i < sz; i++ ){
-=======
 		this.refObj.push( Obj );	
 		for( var i = 0; i < Traits.props.length; i++ ){
->>>>>>> upstream/master
 			prop = Traits.props[i];
 			Obj[prop] = this.readValue( amf.AMF3 );
 		}

--- a/node-amf/deserialize.js
+++ b/node-amf/deserialize.js
@@ -77,8 +77,6 @@ AMFDeserializer.prototype.readU32 = function(){
 /** */
 AMFDeserializer.prototype.readDouble = function(){
 	var s = this.shiftBytes(8);
-	//return this.leParser.toDouble( s );
-	// FIXME:abrod trying this out
 	return this.beParser.toDouble( s );
 }
 
@@ -314,7 +312,6 @@ AMFDeserializer.prototype.readObject = function( version ){
 			else {
 				Traits.dyn = Boolean( n & 8 );
 				Traits.clss = this.readUTF8( amf.AMF3 );
-				console.log("Reading Traits.clss:" +Traits.clss)
 				// iterate over declared member names
 				var proplen = n >> 4;
 				for( var i = 0, prop; i < proplen; i++ ){
@@ -340,7 +337,6 @@ AMFDeserializer.prototype.readObject = function( version ){
 		}
 		// FIXME:abrod - adding type so we can remember it and pass back to origin
 		if( Traits.clss){
-			console.log("Adding type:"+Traits.clss)
 			Obj["type"] = Traits.clss;
 		}
 

--- a/node-amf/deserialize.js
+++ b/node-amf/deserialize.js
@@ -77,7 +77,9 @@ AMFDeserializer.prototype.readU32 = function(){
 /** */
 AMFDeserializer.prototype.readDouble = function(){
 	var s = this.shiftBytes(8);
-	return this.leParser.toDouble( s );
+	//return this.leParser.toDouble( s );
+	// FIXME:abrod trying this out
+	return this.beParser.toDouble( s );
 }
 
 
@@ -312,6 +314,7 @@ AMFDeserializer.prototype.readObject = function( version ){
 			else {
 				Traits.dyn = Boolean( n & 8 );
 				Traits.clss = this.readUTF8( amf.AMF3 );
+				console.log("Reading Traits.clss:" +Traits.clss)
 				// iterate over declared member names
 				var proplen = n >> 4;
 				for( var i = 0, prop; i < proplen; i++ ){
@@ -335,6 +338,12 @@ AMFDeserializer.prototype.readObject = function( version ){
 			prop = Traits.props[i];
 			Obj[prop] = this.readValue( amf.AMF3 );
 		}
+		// FIXME:abrod - adding type so we can remember it and pass back to origin
+		if( Traits.clss){
+			console.log("Adding type:"+Traits.clss)
+			Obj["type"] = Traits.clss;
+		}
+
 		// iterate over dynamic properties until empty string
 		if( Traits.dyn ){
 			while( prop = this.readUTF8( amf.AMF3 ) ){

--- a/node-amf/deserialize.js
+++ b/node-amf/deserialize.js
@@ -335,7 +335,7 @@ AMFDeserializer.prototype.readObject = function( version ){
 			prop = Traits.props[i];
 			Obj[prop] = this.readValue( amf.AMF3 );
 		}
-		// FIXME:abrod - adding type so we can remember it and pass back to origin
+		// adding type to JSON object so we can remember it and pass back to server
 		if( Traits.clss){
 			Obj["type"] = Traits.clss;
 		}

--- a/node-amf/deserialize.js
+++ b/node-amf/deserialize.js
@@ -330,8 +330,8 @@ AMFDeserializer.prototype.readObject = function( version ){
 		}
 		// Have traits - Construct instance
 		// @todo support class mapping somehow?
-		this.refObj.push( Obj );	
-		for( var i = 0; i < Traits.props; i++ ){
+		this.refObj.push( Obj );
+		for( var i = 0, sz = Traits.props.length; i < sz; i++ ){
 			prop = Traits.props[i];
 			Obj[prop] = this.readValue( amf.AMF3 );
 		}

--- a/node-amf/serialize.js
+++ b/node-amf/serialize.js
@@ -290,8 +290,6 @@ AMFSerializer.prototype.writeDouble = function( value, writeMarker ){
 		this.s += '\0\0\0\0\0\0\xF8\x7F';
 	}
 	else {
-		//this.s += this.leParser.fromDouble( value );
-		// FIXME:abrod switching to big endian
 		this.s += this.beParser.fromDouble( value );
 	}
 	return this.s;

--- a/node-amf/serialize.js
+++ b/node-amf/serialize.js
@@ -290,7 +290,9 @@ AMFSerializer.prototype.writeDouble = function( value, writeMarker ){
 		this.s += '\0\0\0\0\0\0\xF8\x7F';
 	}
 	else {
-		this.s += this.leParser.fromDouble( value );
+		//this.s += this.leParser.fromDouble( value );
+		// FIXME:abrod switching to big endian
+		this.s += this.beParser.fromDouble( value );
 	}
 	return this.s;
 }

--- a/node-amf/serialize.js
+++ b/node-amf/serialize.js
@@ -230,12 +230,20 @@ AMFSerializer.prototype.writeObject = function( value ){
 	this.refObj.push( value );
 	// flag with instance, no traits, no externalizable
 	this.writeU29( 11 );
-	this.writeUTF8('Object');
+	// Override object type if present
+	if(value['type'] != null) {
+		this.writeUTF8(value['type']);
+	} else {
+		this.writeUTF8('Object');
+	}
 	// write serializable properties
 	for( var s in value ){
-		if( typeof value[s] !== 'function' && s !== '__amfidx' ){
-			this.writeUTF8(s);
-			this.writeValue( value[s] );
+		// skip override type parameter
+		if( s != 'type' ) {
+			if( typeof value[s] !== 'function' && s !== '__amfidx' ){
+				this.writeUTF8( s );
+				this.writeValue( value[s] );
+			}
 		}
 	}
 	// terminate dynamic props with empty string

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "author": "Tim Whitlock <@timwhitlock> (http://timwhitlock.info/)",
+  "name": "node-amf",
+  "description": "A node AMF library",
+  "version": "0.0.1"
+}


### PR DESCRIPTION
The way we are using amflib, we use typed objects.  We often read objects over the wire that come with a type, and then send them back to the origin server.  In order for that to work, we had to add these patches.  I apologize for the extra merge commits that come along with this.  Mostly I wanted to make sure we submitted it back so that folks can use it if they like.
